### PR TITLE
Fix bug where Tundra would often stomp tundra.lua with the starter template

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -70,6 +70,7 @@ void DriverOptionsInit(DriverOptions* self)
   self->m_IdeGen          = false;
   self->m_DebugSigning    = false;
   self->m_ContinueOnError = false;
+  self->m_QuickstartGen   = false;
   self->m_ThreadCount     = GetCpuCount();
   self->m_WorkingDir      = nullptr;
   self->m_DAGFileName     = ".tundra2.dag";


### PR DESCRIPTION
Tundra would sometimes overwrite `tundra.lua` files as it thought `-Q` was being passed in. This was because `m_QuickstartGen` was never initialized and remained as undefined data, more so than not resulting in `true` (non-zero).